### PR TITLE
Adding overload to accept question mark parameter #3

### DIFF
--- a/src/Nanorm.Sqlite/SqliteConnectionExtensions.cs
+++ b/src/Nanorm.Sqlite/SqliteConnectionExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Data;
+using Nanorm.Sqlite;
 #if NET7_0_OR_GREATER
 using System.Runtime.CompilerServices;
 using Nanorm.Sqlite;
@@ -630,7 +631,7 @@ public static class SqliteConnectionExtensions
     }
 
     private static SqliteCommand CreateCommand(this SqliteConnection connection, string commandText, params SqliteParameter[] parameters) =>
-        connection.CreateCommand(commandText).AddParameters(parameters);
+        connection.CreateCommand(commandText.ParseQuery()).AddParameters(parameters);
 
     private static SqliteCommand CreateCommand(this SqliteConnection connection, string commandText, Action<SqliteParameterCollection>? configureParameters = null)
     {

--- a/src/Nanorm.Sqlite/SqliteParameterExtensions.cs
+++ b/src/Nanorm.Sqlite/SqliteParameterExtensions.cs
@@ -32,4 +32,21 @@ public static class SqliteParameterExtensions
         }
         return name;
     }
+
+    /// <summary>
+    /// Creates an array of <see cref="SqliteParameter"/> from the value
+    /// </summary>
+    /// <param name="value">An array of parameter values</param>
+    /// <returns>An array of parameters</returns>
+    public static SqliteParameter[] AsDbParameter(this object[]? value)
+    {
+        var parameters = new SqliteParameter[value.Length];
+
+        ExceptionHelpers.ThrowIfNullOrEmpty(value);
+
+        for (var i = 0; i < value.Length; i++)
+            parameters[i] = new SqliteParameter($"param{i+1}", value[i]);
+
+        return parameters;
+    }
 }

--- a/src/Nanorm.Sqlite/SqliteQueryExtension.cs
+++ b/src/Nanorm.Sqlite/SqliteQueryExtension.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Nanorm.Sqlite;
+internal static class SqliteQueryExtension
+{
+
+    /// <summary>
+    /// Parses a sqlite parameter query into a named paramenter query
+    /// </summary>
+    /// <param name="query">Command Text</param>
+    /// <returns>Returns a name parameter command text</returns>
+    public static string ParseQuery(this string query)
+    {
+        ExceptionHelpers.ThrowIfNullOrEmpty(query);
+
+        var hasQuestionMarks = query.Contains('?');
+        if(hasQuestionMarks)
+            query = query.Replace("?", "@param");
+        return query;
+    }
+}

--- a/src/Nanorm/ExceptionHelpers.cs
+++ b/src/Nanorm/ExceptionHelpers.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Runtime.CompilerServices;
 
 namespace System;
@@ -25,4 +26,12 @@ internal static class ExceptionHelpers
         throw new ArgumentException("The value cannot be an empty string.", paramName);
     }
 #endif
+
+    public static void ThrowIfNullOrEmpty(object[] argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
+    {
+        if (argument is null)
+            throw new ArgumentException("Array cannot be null", paramName);
+        else if (argument.Length == 0)
+                throw new ArgumentException("Array cannot be empty", paramName);
+    }
 }


### PR DESCRIPTION
- A ParseQuery extension method to parse the query to a named parameter. 
- An overload for AsDbParameter which takes an array of object when working with index parameter is added. 
- The Create Command method has been updated to parse to named parameter if it's an index parameter